### PR TITLE
Add ability to set formatters using an env var

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1.2)
+      simplecov_json_formatter (~> 0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -137,6 +138,7 @@ GEM
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
     simplecov-html (0.12.2)
+    simplecov_json_formatter (0.1.2)
     spoon (0.0.6)
       ffi
     sys-uname (1.2.1)

--- a/README.md
+++ b/README.md
@@ -833,6 +833,20 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
 ])
 ```
 
+## JSON formatter
+
+SimpleCov is packaged with a separate gem called [simplecov_json_formatter](https://github.com/codeclimate-community/simplecov_json_formatter) that provides you with a JSON formatter, this formatter could be useful for different use cases, such as for CI consumption or for reporting to external services.
+
+In order to use it you will need to manually load the installed gem like so:
+
+```ruby
+require "simplecov_json_formatter"
+SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+```
+
+> _Note:_ In case you plan to report your coverage results to CodeClimate services, know that SimpleCov will automatically use the
+>  JSON formatter along with the HTML formatter when the `CC_TEST_REPORTER_ID` variable is present in the environment.
+
 ## Available formatters, editor integrations and hosted services
 
   * [Open Source formatter and integration plugins for SimpleCov](doc/alternate-formatters.md)

--- a/features/config_json_formatter.feature
+++ b/features/config_json_formatter.feature
@@ -1,0 +1,43 @@
+@test_unit @config
+Feature:
+
+  SimpleCov::Formatter::JSONFormatter is one of the
+  formatters included by default, useful for exporting
+  coverage results in JSON format.
+
+  Background:
+    Given I'm working on the project "faked_project"
+  Scenario: With JSONFormatter
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      require 'simplecov_json_formatter'
+      SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+      SimpleCov.at_exit do
+        puts SimpleCov.result.format!
+      end
+      SimpleCov.start do
+        add_group 'Libs', 'lib/faked_project/'
+      end
+      """
+
+    When I successfully run `bundle exec rake test`
+    Then a JSON coverage report should have been generated in "coverage"
+    And the output should contain "JSON Coverage report generated"
+
+  Scenario: When CC_TEST_REPORTER_ID is set in the environment
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      ENV['CC_TEST_REPORTER_ID'] = "9719ac886877886b7e325d1e828373114f633683e429107d1221d25270baeabf"
+      require 'simplecov'
+      SimpleCov.at_exit do
+        puts SimpleCov.result.format!
+      end
+      SimpleCov.start do
+        add_group 'Libs', 'lib/faked_project/'
+      end
+      """
+
+    When I successfully run `bundle exec rake test`
+    Then a JSON coverage report should have been generated in "coverage"
+    And the output should contain "JSON Coverage report generated"

--- a/features/step_definitions/json_steps.rb
+++ b/features/step_definitions/json_steps.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Then /^the JSON coverage report should map:/ do |expected_report|
+  cd(".") do
+    json_report = File.open("coverage/coverage.json").read
+    expected_report = ERB.new(expected_report).result(binding)
+    expect(json_report).to eq(expected_report)
+  end
+end

--- a/features/step_definitions/simplecov_steps.rb
+++ b/features/step_definitions/simplecov_steps.rb
@@ -46,6 +46,16 @@ Then /^a coverage report should have been generated(?: in "([^"]*)")?$/ do |cove
     )
 end
 
+Then /^a JSON coverage report should have been generated(?: in "([^"]*)")?$/ do |coverage_dir|
+  coverage_dir ||= "coverage"
+  steps %(
+    Then the output should contain "Coverage report generated"
+    And a directory named "#{coverage_dir}" should exist
+    And the following files should exist:
+      | #{coverage_dir}/coverage.json      |
+    )
+end
+
 Then /^no coverage report should have been generated(?: in "([^"]*)")?$/ do |coverage_dir|
   coverage_dir ||= "coverage"
   steps %(

--- a/features/test_unit_basic.feature
+++ b/features/test_unit_basic.feature
@@ -35,3 +35,190 @@ Feature:
 
     And the report should be based upon:
       | Unit Tests |
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      ENV['CC_TEST_REPORTER_ID'] = "9719ac886877886b7e325d1e828373114f633683e429107d1221d25270baeabf"
+      require 'simplecov'
+      SimpleCov.start
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see the groups:
+      | name      | coverage | files |
+      | All Files | 91.38%   | 6     |
+
+    And I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.00 %  |
+      | lib/faked_project/some_class.rb         | 80.00 %   |
+      | lib/faked_project/framework_specific.rb | 75.00 %   |
+      | lib/faked_project/meta_magic.rb         | 100.00 %  |
+      | test/meta_magic_test.rb                 | 100.00 %  |
+      | test/some_class_test.rb                 | 100.00 %  |
+
+      # Note: faked_test.rb is not appearing here since that's the first unit test file
+      # loaded by Rake, and only there test_helper is required, which then loads simplecov
+      # and triggers tracking of all other loaded files! Solution for this would be to
+      # configure simplecov in this first test instead of test_helper.
+
+    And the report should be based upon:
+      | Unit Tests |
+
+    And a JSON coverage report should have been generated
+    And the JSON coverage report should map:
+      """
+      {
+        "meta": {
+          "simplecov_version": "<%= SimpleCov::VERSION %>"
+        },
+        "coverage": {
+          "<%= Dir.pwd %>/lib/faked_project.rb": {
+            "lines": [
+              null,
+              null,
+              1,
+              1,
+              1,
+              null,
+              null,
+              null,
+              5,
+              3,
+              null,
+              null,
+              1
+            ]
+          },
+          "<%= Dir.pwd %>/lib/faked_project/framework_specific.rb": {
+            "lines": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              1,
+              1,
+              1,
+              0,
+              null,
+              null,
+              1,
+              0,
+              null,
+              null,
+              1,
+              1,
+              null,
+              null,
+              null
+            ]
+          },
+          "<%= Dir.pwd %>/lib/faked_project/meta_magic.rb": {
+            "lines": [
+              null,
+              null,
+              1,
+              1,
+              1,
+              1,
+              null,
+              null,
+              null,
+              1,
+              1,
+              1,
+              null,
+              null,
+              null,
+              1,
+              1,
+              1,
+              null,
+              1,
+              1,
+              1,
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "<%= Dir.pwd %>/lib/faked_project/some_class.rb": {
+            "lines": [
+              null,
+              null,
+              1,
+              1,
+              1,
+              null,
+              1,
+              2,
+              null,
+              null,
+              1,
+              1,
+              null,
+              null,
+              1,
+              1,
+              1,
+              null,
+              0,
+              null,
+              null,
+              0,
+              null,
+              null,
+              1,
+              null,
+              1,
+              0,
+              null,
+              null
+            ]
+          },
+          "<%= Dir.pwd %>/test/meta_magic_test.rb": {
+            "lines": [
+              null,
+              null,
+              1,
+              null,
+              1,
+              1,
+              1,
+              null,
+              null,
+              1,
+              1,
+              1,
+              1,
+              null,
+              null
+            ]
+          },
+          "<%= Dir.pwd %>/test/some_class_test.rb": {
+            "lines": [
+              null,
+              null,
+              1,
+              null,
+              1,
+              1,
+              2,
+              null,
+              null,
+              1,
+              1,
+              null,
+              null,
+              1,
+              1,
+              null,
+              null
+            ]
+          }
+        }
+      }
+      """

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -1,0 +1,14 @@
+DEFAULT_FORMATTER = "HTML"
+
+configured_formatters = ENV.fetch("SIMPLECOV_FORMATTERS") { DEFAULT_FORMATTER }
+configured_formatters = configured_formatters.split(",")
+configured_formatters.map! do |f|
+  SimpleCov::Formatter.const_get("#{f}Formatter") rescue nil
+end
+configured_formatters.compact
+
+if configured_formatters.count > 1
+  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(configured_formatters)
+else
+  SimpleCov.formatter = configured_formatters.first
+end

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -1,48 +1,12 @@
 # frozen_string_literal: true
+require "simplecov-html"
 
-DEFAULT_FORMATTER = "HTML"
+formatters = [SimpleCov::Formatter::HTMLFormatter]
 
-def constantize_formatter(formatter)
-  SimpleCov::Formatter.const_get("#{formatter}Formatter")
-rescue StandardError
-  warn "SimpleCov #{f} format unrecognized"
-  nil
+# When running under a CI that uses CodeClimate JSON output is expected
+if ENV.fetch("CC_TEST_REPORTER_ID", nil)
+  require "simplecov_json_formatter"
+  formatters.push(SimpleCov::Formatter::JSONFormatter)
 end
 
-def validate_formatters(formatters)
-  raise "None valid formatter was given. Valid default values are 'HTML' and 'JSON'" unless formatters.any?
-
-  formatters
-end
-
-def fetch_env_formatters
-  formatters = ENV.fetch("SIMPLECOV_FORMATTERS") { DEFAULT_FORMATTER }
-  formatters.split(",")
-end
-
-def json_formatter_for_codeclimate(formatters)
-  formatters.push("JSON") if ENV.fetch("CC_TEST_REPORTER_ID") { nil }
-  formatters
-end
-
-def formatters
-  formatters = fetch_env_formatters
-  formatters = json_formatter_for_codeclimate(formatters)
-  formatters.map! do |f|
-    constantize_formatter(f)
-  end
-  formatters.compact!
-  formatters.uniq!
-
-  validate_formatters(formatters)
-end
-
-def configure_formatters(formatters)
-  if formatters.count > 1
-    SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
-  else
-    SimpleCov.formatter = formatters.first
-  end
-end
-
-configure_formatters(formatters)
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
+
 require "simplecov-html"
+module SimpleCov
+  module Formatter
+    class << self
+      def from_env
+        formatters = [SimpleCov::Formatter::HTMLFormatter]
 
-formatters = [SimpleCov::Formatter::HTMLFormatter]
+        # When running under a CI that uses CodeClimate JSON output is expected
+        if ENV.fetch("CC_TEST_REPORTER_ID", nil)
+          require "simplecov_json_formatter"
+          formatters.push(SimpleCov::Formatter::JSONFormatter)
+        end
 
-# When running under a CI that uses CodeClimate JSON output is expected
-if ENV.fetch("CC_TEST_REPORTER_ID", nil)
-  require "simplecov_json_formatter"
-  formatters.push(SimpleCov::Formatter::JSONFormatter)
+        SimpleCov::Formatter::MultiFormatter.new(formatters)
+      end
+    end
+  end
 end
-
-SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -4,16 +4,16 @@ require "simplecov-html"
 module SimpleCov
   module Formatter
     class << self
-      def from_env
+      def from_env(env)
         formatters = [SimpleCov::Formatter::HTMLFormatter]
 
         # When running under a CI that uses CodeClimate, JSON output is expected
-        if ENV.fetch("CC_TEST_REPORTER_ID", nil)
+        if env.fetch("CC_TEST_REPORTER_ID", nil)
           require "simplecov_json_formatter"
           formatters.push(SimpleCov::Formatter::JSONFormatter)
         end
 
-        SimpleCov::Formatter::MultiFormatter.new(formatters)
+        formatters
       end
     end
   end

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -2,18 +2,47 @@
 
 DEFAULT_FORMATTER = "HTML"
 
-configured_formatters = ENV.fetch("SIMPLECOV_FORMATTERS") { DEFAULT_FORMATTER }
-configured_formatters = configured_formatters.split(",")
-configured_formatters.map! do |f|
-  SimpleCov::Formatter.const_get("#{f}Formatter")
+def constantize_formatter(formatter)
+  SimpleCov::Formatter.const_get("#{formatter}Formatter")
 rescue StandardError
   warn "SimpleCov #{f} format unrecognized"
   nil
 end
-configured_formatters.compact!
 
-if configured_formatters.count > 1
-  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(configured_formatters)
-else
-  SimpleCov.formatter = configured_formatters.first
+def validate_formatters(formatters)
+  raise "None valid formatter was given. Valid default values are 'HTML' and 'JSON'" unless formatters.any?
+
+  formatters
 end
+
+def fetch_env_formatters
+  formatters = ENV.fetch("SIMPLECOV_FORMATTERS") { DEFAULT_FORMATTER }
+  formatters.split(",")
+end
+
+def json_formatter_for_codeclimate(formatters)
+  formatters.push("JSON") if ENV.fetch("CC_TEST_REPORTER_ID") { nil }
+  formatters
+end
+
+def formatters
+  formatters = fetch_env_formatters
+  formatters = json_formatter_for_codeclimate(formatters)
+  formatters.map! do |f|
+    constantize_formatter(f)
+  end
+  formatters.compact!
+  formatters.uniq!
+
+  validate_formatters(formatters)
+end
+
+def configure_formatters(formatters)
+  if formatters.count > 1
+    SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
+  else
+    SimpleCov.formatter = formatters.first
+  end
+end
+
+configure_formatters(formatters)

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 DEFAULT_FORMATTER = "HTML"
 
 configured_formatters = ENV.fetch("SIMPLECOV_FORMATTERS") { DEFAULT_FORMATTER }
 configured_formatters = configured_formatters.split(",")
 configured_formatters.map! do |f|
-  SimpleCov::Formatter.const_get("#{f}Formatter") rescue nil
+  SimpleCov::Formatter.const_get("#{f}Formatter")
+rescue StandardError
+  nil
 end
 configured_formatters.compact
 

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -7,7 +7,7 @@ module SimpleCov
       def from_env
         formatters = [SimpleCov::Formatter::HTMLFormatter]
 
-        # When running under a CI that uses CodeClimate JSON output is expected
+        # When running under a CI that uses CodeClimate, JSON output is expected
         if ENV.fetch("CC_TEST_REPORTER_ID", nil)
           require "simplecov_json_formatter"
           formatters.push(SimpleCov::Formatter::JSONFormatter)

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -7,9 +7,10 @@ configured_formatters = configured_formatters.split(",")
 configured_formatters.map! do |f|
   SimpleCov::Formatter.const_get("#{f}Formatter")
 rescue StandardError
+  warn "SimpleCov #{f} format unrecognized"
   nil
 end
-configured_formatters.compact
+configured_formatters.compact!
 
 if configured_formatters.count > 1
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(configured_formatters)

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 # Load default formatter gem
-require "simplecov-html"
-require "simplecov_json_formatter"
 require "pathname"
 require_relative "default_formatter"
 require_relative "profiles/root_filter"

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -2,7 +2,9 @@
 
 # Load default formatter gem
 require "simplecov-html"
+require "simplecov_json_formatter"
 require "pathname"
+require_relative "default_formatter"
 require_relative "profiles/root_filter"
 require_relative "profiles/test_frameworks"
 require_relative "profiles/bundler_filter"
@@ -11,7 +13,6 @@ require_relative "profiles/rails"
 
 # Default configuration
 SimpleCov.configure do
-  formatter SimpleCov::Formatter::HTMLFormatter
   load_profile "bundler_filter"
   load_profile "hidden_filter"
   # Exclude files outside of SimpleCov.root

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -11,6 +11,7 @@ require_relative "profiles/rails"
 
 # Default configuration
 SimpleCov.configure do
+  formatter SimpleCov::Formatter.from_env
   load_profile "bundler_filter"
   load_profile "hidden_filter"
   # Exclude files outside of SimpleCov.root

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -11,7 +11,10 @@ require_relative "profiles/rails"
 
 # Default configuration
 SimpleCov.configure do
-  formatter SimpleCov::Formatter.from_env
+  formatter SimpleCov::Formatter::MultiFormatter.new(
+    SimpleCov::Formatter.from_env(ENV)
+  )
+
   load_profile "bundler_filter"
   load_profile "hidden_filter"
   # Exclude files outside of SimpleCov.root

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "docile", "~> 1.1"
   gem.add_dependency "simplecov-html", "~> 0.11"
+  gem.add_dependency "simplecov_json_formatter", "~> 0.1.2"
 
   gem.files         = Dir["{lib}/**/*.*", "bin/*", "LICENSE", "*.md", "doc/*"]
   gem.require_paths = ["lib"]

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "docile", "~> 1.1"
   gem.add_dependency "simplecov-html", "~> 0.11"
-  gem.add_dependency "simplecov_json_formatter", "~> 0.1.2"
+  gem.add_dependency "simplecov_json_formatter", "~> 0.1"
 
   gem.files         = Dir["{lib}/**/*.*", "bin/*", "LICENSE", "*.md", "doc/*"]
   gem.require_paths = ["lib"]

--- a/spec/default_formatter_spec.rb
+++ b/spec/default_formatter_spec.rb
@@ -5,32 +5,24 @@ require "simplecov_json_formatter"
 
 describe SimpleCov::Formatter do
   describe ".from_env" do
+    let(:env) { {"CC_TEST_REPORTER_ID" => "4c9f1de6193f30799e9a5d5c082692abecc1fd2c6aa62c621af7b2a910761970"} }
+
     context "when CC_TEST_REPORTER_ID environment variable is set" do
-      before do
-        ENV["CC_TEST_REPORTER_ID"] = "4c9f1de6193f30799e9a5d5c082692abecc1fd2c6aa62c621af7b2a910761970"
-      end
-
-      it "returns a MultiFormatter instance with the HTML and JSON formatter" do
-        expect(SimpleCov::Formatter::MultiFormatter).to receive(:new).with([
-                                                                             SimpleCov::Formatter::HTMLFormatter,
-                                                                             SimpleCov::Formatter::JSONFormatter
-                                                                           ])
-
-        described_class.from_env
+      it "returns an array containing the HTML and JSON formatters" do
+        expect(described_class.from_env(env)).to eq([
+                                                      SimpleCov::Formatter::HTMLFormatter,
+                                                      SimpleCov::Formatter::JSONFormatter
+                                                    ])
       end
     end
 
     context "when CC_TEST_REPORTER_ID environment variable isn't set" do
-      before do
-        ENV["CC_TEST_REPORTER_ID"] = nil
-      end
+      let(:env) { {} }
 
-      it "returns a MultiFormatter instance with the HTML and JSON formatter" do
-        expect(SimpleCov::Formatter::MultiFormatter).to receive(:new).with([
-                                                                             SimpleCov::Formatter::HTMLFormatter
-                                                                           ])
-
-        described_class.from_env
+      it "returns an array containing only the HTML formatter" do
+        expect(described_class.from_env(env)).to eq([
+                                                      SimpleCov::Formatter::HTMLFormatter
+                                                    ])
       end
     end
   end

--- a/spec/default_formatter_spec.rb
+++ b/spec/default_formatter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "helper"
+require "simplecov_json_formatter"
+
+describe SimpleCov::Formatter do
+  describe ".from_env" do
+    context "when CC_TEST_REPORTER_ID environment variable is set" do
+      before do
+        ENV["CC_TEST_REPORTER_ID"] = "4c9f1de6193f30799e9a5d5c082692abecc1fd2c6aa62c621af7b2a910761970"
+      end
+
+      it "returns a MultiFormatter instance with the HTML and JSON formatter" do
+        expect(SimpleCov::Formatter::MultiFormatter).to receive(:new).with([
+                                                                             SimpleCov::Formatter::HTMLFormatter,
+                                                                             SimpleCov::Formatter::JSONFormatter
+                                                                           ])
+
+        described_class.from_env
+      end
+    end
+
+    context "when CC_TEST_REPORTER_ID environment variable isn't set" do
+      before do
+        ENV["CC_TEST_REPORTER_ID"] = nil
+      end
+
+      it "returns a MultiFormatter instance with the HTML and JSON formatter" do
+        expect(SimpleCov::Formatter::MultiFormatter).to receive(:new).with([
+                                                                             SimpleCov::Formatter::HTMLFormatter
+                                                                           ])
+
+        described_class.from_env
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed in [https://github.com/codeclimate/test-reporter/issues/413](https://github.com/codeclimate/test-reporter/issues/413)  , this PR has the intention of both adding the capability to modify the formatter through an environmental variable and also to include a json formatter by default.

We are suggesting to use the following json formatter https://github.com/codeclimate-community/simplecov_json_formatter. 

Additionally, as part of the original discussion, it would be the extreme help for those developers using CodeClimate services if we add the possibility to output JSON when the `CC_TEST_REPORTER_ID` is present. 

---
**TO-DO**

- [ ] Get agreement on the implementation
- [ ] Add tests
- [ ] Add documentation to express this new functionality